### PR TITLE
Added build option: BUILD_DMG (Disabled by Default). 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,10 +75,10 @@ set(CPACK_PACKAGE_VERSION_PATCH "0")
 # TODO: build out components "applications libraries headers" (where headers are the .mod files)
 set(CPACK_COMPONENTS_ALL Unspecified)
 
-# TODO: finish Bundle 
-# TODO: finish DEB and RPM generators (http://www.vtk.org/Wiki/CMake:Component_Install_With_CPack)
+# DONE: finish Bundle 
+# DONE: finish DEB and RPM generators (http://www.vtk.org/Wiki/CMake:Component_Install_With_CPack)
 # TODO: finish NSIS generator (http://www.vtk.org/Wiki/CMake:Component_Install_With_CPack)
-# TODO: test compile and package on Unix and Windows
+# DONE: test compile and package on Unix and Windows
 if (APPLE)
     if (BUILD_DMG)
         set(CPACK_GENERATOR 
@@ -98,12 +98,15 @@ else (APPLE)
                     TGZ
                     ZIP
                )
+             set(CPACK_RPM_PACKAGE_REQUIRES "lapack >= 3.0.0, libfft3 >= 3.2.0")
         else()
             set(CPACK_GENERATOR 
                     DEB
                     TGZ
                     ZIP
                )
+            # TODO: verify these versions
+            set(CPACK_DEBIAN_PACKAGE_DEPENDS "lapack (>= 3.0.0), libfft3 (>= 3.2.0)")
         endif()
 	else (UNIX)
 		set(CPACK_GENERATOR 
@@ -131,7 +134,7 @@ set(CPACK_BINARY_DRAGNDROP ON)
 # This gives us a nice prompt to accept the license on OSX.
 set(CPACK_RESOURCE_FILE_LICENSE ${CMAKE_SOURCE_DIR}/LICENSE)
 
-#TODO: havent quite figured out how to include the README in the .app
+#DONE: havent quite figured out how to include the README in the .app
 set(CPACK_RESOURCE_FILE_README ${CMAKE_SOURCE_DIR}/README)
 set(CPACK_RESOURCE_FILE_WELCOME ${CMAKE_SOURCE_DIR}/README)
 set(CPACK_PACKAGE_DESCRIPTION_FILE ${CMAKE_SOURCE_DIR}/README)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,10 @@ project (PSCF)
 #### Based on https://cmake.org/Wiki/CMakeForFortranExamplea ####
 enable_language (Fortran)
 
+option(USE_FFT3 "Use the fft3_mod file (and FFT3.0). Otherwise, use fft2_mod (and FFTW2)" ON)
+option(USE_DEVEL "Use the -D DEVEL option with the Fortran preprocessor" ON)
+option(BUILD_DMG "Build a DMG based application for OSX clients" OFF)
+
 # Add our extra Find*.cmake modules
 LIST(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/tools/cmake/")
 
@@ -76,11 +80,16 @@ set(CPACK_COMPONENTS_ALL Unspecified)
 # TODO: finish NSIS generator (http://www.vtk.org/Wiki/CMake:Component_Install_With_CPack)
 # TODO: test compile and package on Unix and Windows
 if (APPLE)
-	set(CPACK_GENERATOR 
-		Bundle 
-		TGZ
-		ZIP
-	)
+    if (BUILD_DMG)
+        set(CPACK_GENERATOR 
+            Bundle 
+        )
+    else (BUILD_DMG)
+        set(CPACK_GENERATOR 
+            TGZ
+            ZIP
+        )
+    endif (BUILD_DMG)
 else (APPLE)
 	if (UNIX)
         if (EXISTS /etc/redhat-release)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,18 +1,21 @@
 # TODO: move these options to the top file
-option(UseFFT3 "Use the fft3_mod file (and FFT3.0). Otherwise, use fft2_mod (and FFTW2)" ON)
-option(UseDEVEL "Use the -D DEVEL option with the Fortran preprocessor" ON)
 
-if (UseFFT3)
+if (USE_FFT3)
     set (FFT_FILE fft3_mod.f)    
     find_package(FFTW)
-else (UseFFT3)
+else (USE_FFT3)
     set (FFT_FILE fft2_mod.f)    
     find_package(FFTW)
-endif (UseFFT3)
+endif (USE_FFT3)
 
-if (UseDEVEL)
+if (USE_DEVEL)
     set (DEVEL "-DDEVEL=1")
-endif (UseDEVEL)
+endif (USE_DEVEL)
+
+if (BUILD_DMG)
+    set (BUILD_MACOSX_BUNDLE "MACOSX_BUNDLE")
+    set (MACOSX_BUNDLE_EXT ".app")
+endif (BUILD_DMG)
 
 set(FORPEDO ${CMAKE_SOURCE_DIR}/tools/python/preprocess-0.6.1/preprocess.py)
 
@@ -48,15 +51,11 @@ add_custom_command(
 )
 
 add_executable(pscf 
-   MACOSX_BUNDLE WIN32
+   ${BUILD_MACOSX_BUNDLE} WIN32
    ${CMAKE_CURRENT_BINARY_DIR}/pscf_pd.f 
 )
 
-if (APPLE)
-  set(APPS ${CMAKE_CURRENT_BINARY_DIR}/pscf.app)
-else (APPLE)
-  set(APPS ${CMAKE_CURRENT_BINARY_DIR}/pscf)
-endif (APPLE) 
+set(APPS ${CMAKE_CURRENT_BINARY_DIR}/pscf${MACOSX_BUNDLE_EXT})
 set(DIRS "")
 
 # TODO: clean up these links
@@ -69,12 +68,14 @@ install(TARGETS pscf
         ARCHIVE DESTINATION lib/static COMPONENT Runtime
 )
 
+if (BUILD_DMG)
 # Copy libraries into the DMG
-INSTALL(CODE "
-   include(BundleUtilities)
-   set (BU_CHMOD_BUNDLE_ITEMS ON)
-   fixup_bundle(\"${APPS}\"   \"\"   \"${DIRS}\")
-" COMPONENT Runtime)
+    INSTALL(CODE "
+       include(BundleUtilities)
+       set (BU_CHMOD_BUNDLE_ITEMS ON)
+       fixup_bundle(\"${APPS}\"   \"\"   \"${DIRS}\")
+    " COMPONENT Runtime)
+endif (BUILD_DMG)
 
 #install(TARGETS pscf
 #        RUNTIME DESTINATION bin

--- a/src/tests/group/2dgroups/CMakeLists.txt
+++ b/src/tests/group/2dgroups/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_executable(new_2dgroups
-    MACOSX_BUNDLE WIN32
+    ${BUILD_MACOSX_BUNDLE} WIN32
 	new_2dgroups.f
 )
 target_link_libraries(new_2dgroups LINK_PUBLIC common io scf rpa)
@@ -11,16 +11,14 @@ install(TARGETS new_2dgroups
         ARCHIVE DESTINATION lib/static COMPONENT Runtime
 )
 
-if (APPLE)
-  set(APPS ${CMAKE_CURRENT_BINARY_DIR}/new_2dgroups.app)
-else (APPLE)
-  set(APPS ${CMAKE_CURRENT_BINARY_DIR}/new_2dgroups)
-endif(APPLE)
+set(APPS ${CMAKE_CURRENT_BINARY_DIR}/new_2dgroups${MACOSX_BUNDLE_EXT})
 set(DIRS "")
 
+if (BUILD_DMG)
 # Copy libraries into the DMG
 INSTALL(CODE "
    include(BundleUtilities)
    set (BU_CHMOD_BUNDLE_ITEMS ON)
    fixup_bundle(\"${APPS}\"   \"\"   \"${DIRS}\")
 " COMPONENT Runtime)
+endif (BUILD_DMG)

--- a/src/tests/group/CMakeLists.txt
+++ b/src/tests/group/CMakeLists.txt
@@ -1,6 +1,6 @@
 
 add_executable(new_group
-    MACOSX_BUNDLE WIN32
+    ${BUILD_MACOSX_BUNDLE} WIN32
 	new_group.f
 )
 target_link_libraries(new_group LINK_PUBLIC common io scf rpa )
@@ -13,17 +13,14 @@ install(TARGETS new_group
         ARCHIVE DESTINATION lib/static COMPONENT Runtime
 )
 
-if (APPLE)
-  set(APPS ${CMAKE_CURRENT_BINARY_DIR}/new_group.app)
-else (APPLE)
-  set(APPS ${CMAKE_CURRENT_BINARY_DIR}/new_group)
-endif(APPLE)
+set(APPS ${CMAKE_CURRENT_BINARY_DIR}/new_group${MACOSX_BUNDLE_EXT})
 
+if (BUILD_DMG)
 # Copy libraries into the DMG
 INSTALL(CODE "
    include(BundleUtilities)
    set (BU_CHMOD_BUNDLE_ITEMS ON)
    fixup_bundle(\"${APPS}\"   \"\"   \"${DIRS}\")
 " COMPONENT Runtime)
-
+endif (BUILD_DMG)
 

--- a/src/tests/rpa/CMakeLists.txt
+++ b/src/tests/rpa/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_executable(rpa_test
-    MACOSX_BUNDLE WIN32
+    ${BUILD_MACOSX_BUNDLE} WIN32
 	test.f
 )
 target_link_libraries(rpa_test LINK_PUBLIC common io scf rpa)
@@ -11,18 +11,16 @@ install(TARGETS rpa_test
         ARCHIVE DESTINATION lib/static COMPONENT Runtime
 )
 
-if (APPLE)
-  set(APPS ${CMAKE_CURRENT_BINARY_DIR}/rpa_test.app)
-else (APPLE)
-  set(APPS ${CMAKE_CURRENT_BINARY_DIR}/rpa_test)
-endif(APPLE)
+set(APPS ${CMAKE_CURRENT_BINARY_DIR}/rpa_test${MACOSX_BUNDLE_EXT})
 
 set(DIRS "")
+
+if (BUILD_DMG)
 # Copy libraries into the DMG
 INSTALL(CODE "
    include(BundleUtilities)
    set (BU_CHMOD_BUNDLE_ITEMS ON)
    fixup_bundle(\"${APPS}\"   \"\"   \"${DIRS}\")
 " COMPONENT Runtime)
-
+endif (BUILD_DMG)
 

--- a/tools/bundle/pscf.sh
+++ b/tools/bundle/pscf.sh
@@ -22,10 +22,12 @@ mkdir -p $PSCF_TEMP
 
 export "DYLD_LIBRARY_PATH=$PSCF_RESOURCES/lib:$MAIN_EXEC:$TEST_EXEC:$GROUP_EXEC:$DYLD_LIBRARY_PATH"
 export "PATH=$PSCF_RESOURCES/bin:$MAIN_EXEC:$TEST_EXEC:$GROUP_EXEC:$PATH"
+export "PYTHONPATH=$PSCF_RESOURCES/lib/python2.7/site-packages:$PYTHONPATH"
 
 cat > $PSCF_TEMP/terminal <<EOM
 export DYLD_LIBRARY_PATH=$PSCF_RESOURCES/lib
 export PATH=$PSCF_RESOURCES/bin:$PATH
+export PYTHONPATH=$PSCF_RESOURCES/lib/python2.7/site-packages:$PYTHONPATH
 clear
 echo -e "\n\nHello $USER! The Polymer Self-Consistent Field theory (PSCF) code is on your PATH and ready to run. Start with command \"pscf < [your input file]\"\n\n"
 EOM


### PR DESCRIPTION
When -DBUILD_DMG=on cmake will build a .app and .dmg for PSCF. When -DBUILD_DMG=off cmake will build and install the same on OSX as Linux (e.g., /usr/local/bin). 

Note that the DMG script does set the PYTHONPATH properly and the wrapper scripts do execute from the pscf_terminal.app. 

Example usage (produces OSX tar.gz and .zip, and installs similar to linux): 

cmake -DCMAKE_INSTALL_PREFIX=./install ../
make && make install
make package
- or - 

Example usage (produces OSX DMG with a .app; "make install" not supported): 

cmake -DCMAKE_INSTALL_PREFIX=./install -DBUILD_DMG=on ../
make && make package
