### PR TITLE
Added pscf-env

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,7 +152,7 @@ INSTALL(FILES ${CMAKE_SOURCE_DIR}/LICENSE DESTINATION share/pscf RENAME LICENSE.
 endif (APPLE AND BUILD_DMG)
 
 install(PROGRAMS 
-        tools/bin/pscf-read-outfile tools/bin/pscf-read-sweep
+        tools/bin/pscf-read-outfile tools/bin/pscf-read-sweep tools/bin/pscf-env
         DESTINATION bin)
 
 #INSTALL(DIRECTORY ${CMAKE_SOURCE_DIR}/tools/bin DESTINATION .)

--- a/tools/bin/pscf-env
+++ b/tools/bin/pscf-env
@@ -8,7 +8,7 @@ export PATH=$script_dir:$PATH
 export PYTHONPATH=$base_dir/lib/python2.7/site-packages:$PYTHONPATH
 
 PLATFORM=$( uname -s )
-if [[ "$PLATFORM" -eq "Darwin" ]]; then 
+if [ $PLATFORM -eq "Darwin" ]; then 
     if [ -d $base_dir/pscf.app ]; then 
         export PATH=$base_dir/pscf.app/Contents/MacOS:$PATH
     fi

--- a/tools/bin/pscf-env
+++ b/tools/bin/pscf-env
@@ -8,7 +8,7 @@ export PATH=$script_dir:$PATH
 export PYTHONPATH=$base_dir/lib/python2.7/site-packages:$PYTHONPATH
 
 PLATFORM=$( uname -s )
-if [ $PLATFORM -eq "Darwin" ]; then 
+if [ $PLATFORM == "Darwin" ]; then 
     if [ -d $base_dir/pscf.app ]; then 
         export PATH=$base_dir/pscf.app/Contents/MacOS:$PATH
     fi

--- a/tools/bin/pscf-env
+++ b/tools/bin/pscf-env
@@ -1,0 +1,18 @@
+#!/bin/bash 
+
+run_from_dir=$( pwd )                                                                                                                                                                                                                                               
+script_dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+base_dir=$( cd "$( dirname "${script_dir}" )" && pwd )
+
+export PATH=$script_dir:$PATH
+export PYTHONPATH=$base_dir/lib/python2.7/site-packages:$PYTHONPATH
+
+PLATFORM=$( uname -s )
+if [[ "$PLATFORM" -eq "Darwin" ]]; then 
+    if [ -f $base_dir/pscf.app ]; then 
+        export PATH=$base_dir/pscf.app/Contents/MacOS:$PATH
+    fi
+    export DYLD_LIBRARY_PATH=$base_dir/lib:$DYLD_LIBRARY_PATH
+else 
+    export LD_LIBRARY_PATH=$base_dir/lib:$LD_LIBRARY_PATH
+fi

--- a/tools/bin/pscf-env
+++ b/tools/bin/pscf-env
@@ -9,7 +9,7 @@ export PYTHONPATH=$base_dir/lib/python2.7/site-packages:$PYTHONPATH
 
 PLATFORM=$( uname -s )
 if [[ "$PLATFORM" -eq "Darwin" ]]; then 
-    if [ -f $base_dir/pscf.app ]; then 
+    if [ -d $base_dir/pscf.app ]; then 
         export PATH=$base_dir/pscf.app/Contents/MacOS:$PATH
     fi
     export DYLD_LIBRARY_PATH=$base_dir/lib:$DYLD_LIBRARY_PATH

--- a/tools/bundle/HOWTO_INSTALL_OSX.txt
+++ b/tools/bundle/HOWTO_INSTALL_OSX.txt
@@ -25,3 +25,22 @@ https://support.apple.com/kb/PH18657?locale=en_US:
 
 The app is saved as an exception to your security settings, and you can open it
 in the future by double-clicking it just as you can any registered app.
+
+
+Install the Command Line Tools
+===============================
+Users who wish to run `pscf` from any Terminal (i.e., outside of the
+pscf_terminal.app) can append the following snippet to their $HOME/.bashrc:
+
+#### Enable PSCF CLI #####
+source /Applications/pscf_terminal.app/Contents/Resources/bin/pscf-env
+#### END ####
+
+New Terminal windows will then have the right environment to run `pscf` and the
+python helper applications. Confirm the CLI functions properly by running
+"which pscf" in a fresh terminal: 
+
+Last login: Mon Apr 18 13:31:28 on ttys011
+• [habushu:~] evan $ which pscf
+/Applications/pscf_terminal.app/Contents/Resources/pscf.app/Contents/MacOS/pscf
+• [habushu:~] evan $ 


### PR DESCRIPTION
The pscf-env script will export paths properly for OSX and Linux environments. Users can append to their .bashrc / .profile / .bash_profile: 

source ${INSTALL_PREFIX}/bin/pscf-env 

This sets the environment properly for both the Fortran binary and the python scripts.  Obviously the INSTALL_PREFIX depends on what CMAKE_INSTALL_PREFIX was set at compile/package time, but on OSX we can guarantee to some degree that it will be /Applications/pscf_terminal.app/Contents/Resources/bin, which is the case if the .app is dragged to the Applications link when the DMG is opened. 
