### PR TITLE
Ensured that make package twice does build proper DMG

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -55,7 +55,7 @@ add_executable(pscf
    ${CMAKE_CURRENT_BINARY_DIR}/pscf_pd.f 
 )
 
-set(APPS ${CMAKE_CURRENT_BINARY_DIR}/pscf${MACOSX_BUNDLE_EXT})
+set(APPS "${CMAKE_CURRENT_BINARY_DIR}/pscf${MACOSX_BUNDLE_EXT}")
 set(DIRS "")
 
 # TODO: clean up these links
@@ -70,11 +70,11 @@ install(TARGETS pscf
 
 if (BUILD_DMG)
 # Copy libraries into the DMG
-    INSTALL(CODE "
-       include(BundleUtilities)
-       set (BU_CHMOD_BUNDLE_ITEMS ON)
-       fixup_bundle(\"${APPS}\"   \"\"   \"${DIRS}\")
-    " COMPONENT Runtime)
+INSTALL(CODE "
+   include(BundleUtilities)
+   set (BU_CHMOD_BUNDLE_ITEMS ON)
+   fixup_bundle(\"${APPS}\"   \"\"   \"${DIRS}\")
+" COMPONENT Runtime)
 endif (BUILD_DMG)
 
 #install(TARGETS pscf


### PR DESCRIPTION
These changes should not be required, but can't hurt. 
