### PR TITLE
Fix typo in linux installation instructions + additional recommended package.

### DIFF
--- a/doc/user-man/binary.rst
+++ b/doc/user-man/binary.rst
@@ -70,11 +70,13 @@ files.  To install from binary on Ubuntu:
 
         - libfftw3-3
         - liblapack3
+        - libatlas-base-dev
 
     To install these packages using apt-get, enter::
 
-        sudo apt-get libfftw3-3
-        sudo apt-get liblapack3
+        sudo apt-get install libfftw3-3
+        sudo apt-get install liblapack3
+        sudo apt-get install libatlas-base-dev
 
   * Download the .deb package from the PSCF home page. This is a file
     with a name of the form pscf-<version>-Linux.deb, where <version>


### PR DESCRIPTION
`apt-get` is missing `install` command in "Ubuntu or Debian Linux" -section of the user manual.

Also one is recommended to install `libatlas-base-dev` -package. Otherwise pscf complains (in Ubuntu 16.04):
`pscf: error while loading shared libraries: libf77blas.so.3: cannot open shared object file: No such file or directory`
