### PR TITLE
Prevent N_monomer > 3 in AM algorithm, and fix errors in python tools

### DIFF
--- a/src/iterate_mod.fp.f90
+++ b/src/iterate_mod.fp.f90
@@ -1182,6 +1182,9 @@ contains
              +  chi(2,3)*rho(1,k+1) + chi(1,3)*rho(2,k+1) )/N_monomer &!
                       - omega(alpha,k+1)
             end do
+         else
+            write(6,*) 'Error: Anderson Mixing is only implemented for N_monomer = 2 or 3'
+            stop
          endif
    
       end do

--- a/tools/python/pscf/fieldfile.py
+++ b/tools/python/pscf/fieldfile.py
@@ -1,4 +1,4 @@
-from io import IO, IoException
+from io_pscf import IO, IoException
 from version import Version
 import string
 import sys
@@ -44,11 +44,11 @@ class FieldFile(object):
         The file named filename is opened and closed within this function.
         '''
         self.file = open(filename, 'r')
-	self._io   = IO()
-	file = self.file
+        self._io   = IO()
+        file = self.file
 
         # Read version line
-	self.version = Version(self.file)
+        self.version = Version(self.file)
 
         self._input_unit_cell()
         self.group_name = self._input_var('char')
@@ -85,7 +85,7 @@ class FieldFile(object):
             self.counts.append(int(data[j]))
 
         self.file.close()
-	self.file = None
+        self.file = None
 
     def write(self, file, major=1, minor=0):
         '''
@@ -105,9 +105,9 @@ class FieldFile(object):
             file = temp
         self.file = file
            
-	self.version.major = major
-	self.version.minor = minor
-	self.version.write(file)
+        self.version.major = major
+        self.version.minor = minor
+        self.version.write(file)
 
         self._output_unit_cell()
         self._output_var('char', 'group_name')
@@ -123,7 +123,7 @@ class FieldFile(object):
             file.write('%6d' % self.counts[i])
             file.write("\n")
 
-	file.close()
+        file.close()
         self.file = None
 
     def addMonomer(self, value = 0.0):
@@ -177,14 +177,14 @@ class FieldFile(object):
 
     # Output methods (output by name)
     def _output_var(self, type, name, f='A'):
-        if self.__dict__.has_key(name):
+        if name in self.__dict__:
             data = self.__dict__[name]
-	    self._io.output_var(self.file, type, data, name, f)
+            self._io.output_var(self.file, type, data, name, f)
 
     def _output_vec(self, type, name, n=None, s='R', f='A'):
-        if self.__dict__.has_key(name):
+        if name in self.__dict__:
             data = self.__dict__[name]
-	    self._io.output_vec(self.file, type, data, n, name, s, f)
+            self._io.output_vec(self.file, type, data, n, name, s, f)
 
     def _input_unit_cell(self):
         ''' Analog of subroutine _input_unit_cell in unit_cell_mod.f '''

--- a/tools/python/pscf/io_pscf.py
+++ b/tools/python/pscf/io_pscf.py
@@ -16,7 +16,7 @@ class IO:
         """
         Default construct an initially empty object.
         """
-	self.comment = None
+        self.comment = None
 
     def input_comment(self, file, comment=None):
         """
@@ -45,8 +45,8 @@ class IO:
                -- 'N' -> no comment string
         """
         if f == 'A':
-	    if not self.input_comment(file, comment):
-	        return None
+            if not self.input_comment(file, comment):
+                return None
         data = file.readline().strip()
         if type == 'int':
             return int(data)
@@ -60,7 +60,7 @@ class IO:
             elif data in ['F','false','FALSE','FALSE']:
                 return 0
             else:
-                raise "Invalid logical variable:", data
+                raise("Invalid logical variable:", data)
         else:
             raise 'Illegal type in input_var'
     
@@ -78,8 +78,8 @@ class IO:
                -- 'C' -> column vector (n lines)
         """
         if f == 'A':
-	    if not self.input_comment(file,comment):
-	        return None
+            if not self.input_comment(file,comment):
+                return None
         if s == 'R':   # Row Vector
             data = file.readline().split()
             if n:
@@ -116,8 +116,8 @@ class IO:
              -- 'L' -> symmetric lower triangular (0 diagonals)
         """
         if f == 'A':
-	    if not self.input_comment(file,comment):
-	        return None
+            if not self.input_comment(file,comment):
+                return None
         # Emulate initialization of m x n array
         if not n:
            n = m
@@ -170,8 +170,8 @@ class IO:
         elif type == 'real':
             return '%20.10E' % data
         elif type == 'char':
-    	    data = "'" + data + "'" 
-	    return "%20s" % data 
+            data = "'" + data + "'" 
+            return "%20s" % data 
         elif type == 'logic':
             if data:
                 data = 'T'
@@ -221,8 +221,8 @@ class IO:
         s    -- 'R' -> row vector (one line)
              -- 'C' -> column vector (n lines)
         """
-	if not n:
-  	    n = len(data)
+        if not n:
+            n = len(data)
         if f == 'A':
             self.output_comment(file, comment)
         for i in range(n):
@@ -248,7 +248,7 @@ class IO:
              -- 'S' -> symmetric
              -- 'L' -> symmetric lower triangular (0 diagonals)
         """
-	if not m:
+        if not m:
            m = len(data)
         if not n:
            n = m

--- a/tools/python/pscf/outfile.py
+++ b/tools/python/pscf/outfile.py
@@ -1,8 +1,6 @@
-from io import IO, IoException
+from io_pscf import IO
 from version import Version
 from paramfile import ParamFile
-import string 
-import sys
 
 class OutFile(ParamFile):
     """

--- a/tools/python/pscf/paramfile.py
+++ b/tools/python/pscf/paramfile.py
@@ -1,7 +1,6 @@
-from io import IO, IoException
+from io_pscf import IO, IoException
 from version import Version
 import string
-import sys
 
 class ParamFile(object):
     """

--- a/tools/python/pscf/sweep.py
+++ b/tools/python/pscf/sweep.py
@@ -1,5 +1,5 @@
 from outfile import OutFile
-import sys, os, string
+import os, string
 
 class Sweep(object):
     """

--- a/tools/python/pscf/version.py
+++ b/tools/python/pscf/version.py
@@ -1,6 +1,3 @@
-from io import IO, IoException
-import string 
-
 class Version(object):
     '''
     Abstract representation of a file format version tag
@@ -16,13 +13,13 @@ class Version(object):
         '''
 
         # Read first line to determine file format
-	line = file.readline().strip()
+        line = file.readline().strip()
         if line == '':
             self.major = 0
             self.minor = 9
         else:
-  	    line = line.split()
-	    if line[0] == 'format':
+            line = line.split()
+            if line[0] == 'format':
                 self.major = int(line[1])
                 self.minor = int(line[2])
             else: 
@@ -44,7 +41,7 @@ class Version(object):
 
     def ge(self, major, minor):
         if (self.major >= major and self.minor >= minor):
-            return true
+            return True
         else:
-            return false
+            return False
 


### PR DESCRIPTION
This pull request is primarily to patch a bug in `src/iterate_mod.fp.f90`. The bug was that the Anderson Mixing algorithm permitted the use of N_monomer > 3, but did not properly calculate the residuals for this system, resulting in quick but wrong conversion to an answer with 0 error from the residuals. This edit simply stops the execution of the code if a user tries to use N_monomer > 3 rather than allowing the answer to be calculated.

------

I am also including in this pull request a fixed version of the python tools in the directory tools/python/pscf/, because the versions of the tools that exist in the current github directory do not work for me in either python2 or python3. This is an issue I hoped to fix because, if you've added these tools to your PYTHONPATH and they are broken, you can't do anything in python until they're all fixed because python gives you errors for the files in your PYTHONPATH even if you aren't importing/using them. 

The amendments included in this pull request fix all of the errors that I have run into when using the python tools, allowing them to be run by users without being fixed beforehand. The issues I ran into were the following:

- A few of the "tabs" in the python scripts were actually `\t` tabs rather than spaces like they should be, and python gave me errors that said `inconsistent use of tabs and spaces`. In each place where this occurred, I replaced the tabs with spaces.
- The filename `io.py` is seemingly used for something else somewhere in python, because I ran into a bug once working on an entirely unrelated python project due to overlapping files named `io.py`. So, I renamed it `io_pscf.py`.
- There are a few places where the code says `if self.__dict__.has_key(name)`, and I replaced these with `if name in self.__dict__` because the former is specific to python2 but the latter works in both python2 and python3. 
- I deleted some import statements that import packages that are unused in the scripts.
- Changed `true` to `True` and `false` to `False` in a few places for proper syntax.

The python tools were initially written for python2.7, but I am able to run them in python3.8 after having made the above changes. However, the changes shouldn't prevent them from still working properly in python2.7 as well, since none of the changes break compatibility with python2.7.

------

Changes:
	modified:   src/iterate_mod.fp.f90
	modified:   tools/python/pscf/fieldfile.py
	renamed/modified:   tools/python/pscf/io.py -> tools/python/pscf/io_pscf.py
	modified:   tools/python/pscf/outfile.py
	modified:   tools/python/pscf/paramfile.py
	modified:   tools/python/pscf/sweep.py
	modified:   tools/python/pscf/version.py