### PR TITLE
Fixed bug that gives pressure=NaN when a species has phi=0

### DIFF
--- a/src/scf_mod.fp.f90
+++ b/src/scf_mod.fp.f90
@@ -872,10 +872,14 @@ contains
    if (present(pressure)) then
       pressure = -f_Helmholtz
       do i = 1, N_chain
-         pressure = pressure + mu_chain(i)*phi_chain(i)/chain_length(i)
+         if ( phi_chain(i) > 1.0E-8) then
+            pressure = pressure + mu_chain(i)*phi_chain(i)/chain_length(i)
+         end if
       end do
       do i = 1, N_solvent
-         pressure = pressure + mu_solvent(i)*phi_solvent(i)/solvent_size(i)
+         if ( phi_solvent(i) > 1.0E-8) then
+            pressure = pressure + mu_solvent(i)*phi_solvent(i)/solvent_size(i)
+         end if
       end do
    end if
  


### PR DESCRIPTION
When a solvent or polymer is included in the param file but has phi=0, the calculated pressure of the system is erroneously reported as NaN because the software is calculating 0*(-inf) as the contribution of the nonexistent species to the pressure. This pull request will fix this bug for fd1d, pspc, and pspg by only calculating the free energy contributions of species for which phi>1E-08. I ran a quick test and it compiles and runs correctly.

This is the same bug that was addressed by my recent pull request in pscfpp, except in the Fortran code it is only the pressure that was reported as NaN, the free energy was being calculated correctly.