### PR TITLE
Splitting out combinatoric contribution to free energy.

### DIFF
--- a/src/pscf.fp.f90
+++ b/src/pscf.fp.f90
@@ -111,7 +111,7 @@ program pscf
 
    !# ifdef DEVEL
    ! Variables for free energy decomposition
-   real(long)      :: f_component(4)  !
+   real(long)      :: f_component(5)  !
    real(long)      :: overlap(:,:)    ! overlap integrals
    allocatable     :: overlap
    !# endif
@@ -1170,7 +1170,8 @@ contains ! internal subroutines of program pscf
    call output(f_component(1),'f_enthalpy')
    call output(f_component(2),'f_head')
    call output(f_component(3),'f_tail')
-   call output(f_component(4),'f_excess')
+   call output(f_component(4),'f_junction')
+   call output(f_component(5),'f_combinatoric')
    !# endif
 
    ! Timing and resource statistics

--- a/src/scf_mod.fp.f90
+++ b/src/scf_mod.fp.f90
@@ -575,6 +575,7 @@ contains
    !       f_comp(2) = conformational energy of first block
    !       f_comp(3) = conformational energy of last  block
    !       f_comp(4) = junction translational energy (diblock)
+   !       f_comp(5) = combinatoric contribution.
    !
    !    b) Calculation of junction translational entropy is correct
    !       only for diblocks, for which there is only one junction
@@ -695,16 +696,18 @@ contains
    !## end do
    !## fjct  = fjct  / rnodes
    ! --------------------------------------------
+   fcomb = 0.0_long
    fjct = 0.0_long
    do i=1, N_chain
-      fjct = fjct + phi_chain(i) / chain_length(i)
+      fcomb = fcomb + phi_chain(i) / chain_length(i) * ( log( phi_chain(i) ) - 1 )
    end do
-   fjct = f_tot + fjct - enthalpy - fhead - ftail
+   fjct = f_tot - fcomb - enthalpy - fhead - ftail
 
    f_comp(1) = enthalpy   ! overall interaction energy
    f_comp(2) = fhead      ! conformational energy of first block
    f_comp(3) = ftail      ! conformational energy of last  block
    f_comp(4) = fjct       ! junction translational energy (diblock)
+   f_comp(5) = fcomb      ! combinatoric contribution 
 
    end subroutine divide_energy
    !=============================================================


### PR DESCRIPTION
This is code I wrote a long time ago (Oct 2021) and never made a PR for. It makes the simple modification to split out combinatoric and junction entropy contributions to the excess free energy. I think it is correct.